### PR TITLE
union find에 대해 공부했습니다. 

### DIFF
--- a/13주차/fine/CourseSchedule.swift
+++ b/13주차/fine/CourseSchedule.swift
@@ -1,0 +1,38 @@
+class Solution {
+    func canFinish(_ numCourses: Int, _ prerequisites: [[Int]]) -> Bool {
+        var graph = [Int: [Int]]()
+        
+        // 그래프 생성
+        for prereq in prerequisites {
+            let course = prereq[0]
+            let prerequisite = prereq[1]
+            graph[course, default: []].append(prerequisite)
+        }
+        
+        var visited = [Int: Bool]()
+        
+        // DFS 함수 정의
+        func dfs(_ course: Int) -> Bool {
+            if visited[course] == true { return false }
+            if visited[course] == false { return true }
+            
+            visited[course] = true
+            
+            if let prerequisites = graph[course] {
+                for prereq in prerequisites {
+                    if !dfs(prereq) { return false }
+                }
+            }
+            
+            visited[course] = false
+            return true
+        }
+        
+        // 모든 코스에 대해 DFS 실행
+        for course in 0..<numCourses {
+            if !dfs(course) { return false }
+        }
+        
+        return true
+    }
+}            

--- a/13주차/fine/NumberofConnectedComponentsInAnUndirectedGraph.swift
+++ b/13주차/fine/NumberofConnectedComponentsInAnUndirectedGraph.swift
@@ -1,0 +1,51 @@
+class Solution {
+    class UnionFind {
+        private var parent: [Int]
+        private var rank: [Int]
+        
+        init(_ n: Int) {
+            parent = Array(0..<n)
+            rank = Array(repeating: 0, count: n)
+        }
+        
+        func find(_ x: Int) -> Int {
+            if parent[x] != x {
+                parent[x] = find(parent[x])  // 경로 압축
+            }
+            return parent[x]
+        }
+        
+        func union(_ x: Int, _ y: Int) {
+            let rootX = find(x)
+            let rootY = find(y)
+            
+            if rootX != rootY {
+                if rank[rootX] < rank[rootY] {
+                    parent[rootX] = rootY
+                } else if rank[rootX] > rank[rootY] {
+                    parent[rootY] = rootX
+                } else {
+                    parent[rootY] = rootX
+                    rank[rootX] += 1
+                }
+            }
+        }
+    }
+    
+    func countComponents(_ n: Int, _ edges: [[Int]]) -> Int {
+        let uf = UnionFind(n)
+        
+        // 모든 엣지에 대해 union 연산 수행
+        for edge in edges {
+            uf.union(edge[0], edge[1])
+        }
+        
+        // 연결 요소의 수 계산
+        var components = Set<Int>()
+        for i in 0..<n {
+            components.insert(uf.find(i))
+        }
+        
+        return components.count
+    }
+}

--- a/13주차/fine/ValidTree.swift
+++ b/13주차/fine/ValidTree.swift
@@ -1,0 +1,37 @@
+class Solution {
+    func validTree(_ n: Int, _ edges: [[Int]]) -> Bool {
+        // 엣지 개수 확인
+        if edges.count != n - 1 {
+            return false
+        }
+        
+        // Union-Find 초기화
+        var parent = Array(0..<n)
+        
+        func find(_ x: Int) -> Int {
+            if parent[x] != x {
+                parent[x] = find(parent[x])  // 경로 압축
+            }
+            return parent[x]
+        }
+        
+        func union(_ x: Int, _ y: Int) -> Bool {
+            let rootX = find(x)
+            let rootY = find(y)
+            if rootX == rootY {
+                return false  // 사이클 발견
+            }
+            parent[rootX] = rootY
+            return true
+        }
+        
+        // 각 엣지에 대해 union 연산 수행
+        for edge in edges {
+            if !union(edge[0], edge[1]) {
+                return false
+            }
+        }
+        
+        return true
+    }
+}


### PR DESCRIPTION
## Union-Find (또는 Disjoint Set) 알고리즘이란?

Union-Find는 여러 개의 원소가 있을 때, 어떤 원소들이 같은 집합에 속해 있는지를 효율적으로 관리하는 방법입니다. 

Union-Find를 구현하기 위해 다음 두 함수가 필요합니다. 
1. Find: 특정 원소가 어떤 집합에 속해 있는지 찾습니다.
2. Union: 두 집합을 하나로 합칩니다.

Union-Find의 주요 특징
- 각 집합은 트리 구조로 표현됩니다.
- 경로 압축(Path Compression)과 Union by Rank 최적화를 통해 거의 상수 시간에 가까운 연산 속도를 제공합니다.

각 문제에서의 Union-Find 활용:

1. Valid Tree 문제:
   목적: 주어진 그래프가 유효한 트리인지 확인
   활용 방법:
   - 각 노드를 개별 집합으로 초기화합니다.
   - 주어진 엣지들에 대해 Union 연산을 수행합니다.
   - **Union 과정에서 이미 같은 집합에 속한 노드들을 연결하려고 하면 사이클이 존재한다고 판단**합니다.
   - **엣지의 개수가 (노드 수 - 1)인지 확인하여 모든 노드가 연결되어 있는지 검증**합니다.

   ```swift
   if edges.count != n - 1 { return false }
   let uf = UnionFind(n)
   for edge in edges {
       if !uf.union(edge[0], edge[1]) { return false }
   }
   return true
   ```

2. 연결 요소(Connected Components) 개수 세기 문제:
   목적: 그래프 내의 연결된 부분 그래프의 개수 찾기
   활용 방법:
   - 각 노드를 개별 집합으로 초기화합니다.
   - 주어진 모든 엣지에 대해 Union 연산을 수행합니다.
   - 최종적으로 서로 다른 루트 노드의 개수를 세어 연결 요소의 수를 구합니다.

   ```swift
   let uf = UnionFind(n)
   for edge in edges {
       uf.union(edge[0], edge[1])
   }
   var components = Set<Int>()
   for i in 0..<n {
       components.insert(uf.find(i))
   }
   return components.count
   ```